### PR TITLE
fix: default Ingress pathType

### DIFF
--- a/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-ingress-template.yaml
@@ -3,6 +3,7 @@
 {{- $fullName := include "cost-analyzer.fullname" . -}}
 {{- $serviceName := include "cost-analyzer.serviceName" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
+{{- $ingressPathType := .Values.ingress.pathType -}}
 {{- $apiV1 := false -}}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 {{- $apiV1 = true -}}
@@ -43,7 +44,7 @@ spec:
         {{- range $ingressPaths }}
           {{- if $apiV1 }}
           - path: {{ . }}
-            pathType: Prefix
+            pathType: {{ $ingressPathType }}
             backend:
               service:
                 name: {{ $serviceName }}

--- a/cost-analyzer/values.yaml
+++ b/cost-analyzer/values.yaml
@@ -241,6 +241,7 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   paths: ["/"] # There's no need to route specifically to the pods-- we have an nginx deployed that handles routing
+  pathType: ImplementationSpecific
   hosts:
     - cost-analyzer.local
   tls: []


### PR DESCRIPTION
Set to `ImplementationSpecific`, which should work for any Ingress controller. Can be overridden by end-user.

## What does this PR change?
Ingress pathType


## Does this PR rely on any other PRs?
No
- 
- 


## How does this PR impact users? (This is the kind of thing that goes in release notes!)
Bug fix - v1.88.0 breaks Ingress if `class: gce-internal` (other classes almost certainly also affected)


## Links to Issues or ZD tickets this PR addresses or fixes

- 
- 


## How was this PR tested?
Applied to our environment

## Have you made an update to documentation?
No
